### PR TITLE
Make Torch libraries require-able and runnable

### DIFF
--- a/framework/Torch.h
+++ b/framework/Torch.h
@@ -4,11 +4,11 @@
 
 #import <UIKit/UIKit.h>
 
-#import "lua.h"
-#import "TH/TH.h"
-#import "luaT.h"
-#import "lualib.h"
-#import "lauxlib.h"
+#import <Torch/lua.h>
+#import <Torch/TH/TH.h>
+#import <Torch/luaT.h>
+#import <Torch/lualib.h>
+#import <Torch/lauxlib.h>
 
 int luaopen_libtorch(lua_State *L);
 int luaopen_libnn(lua_State *L);

--- a/framework/Torch.m
+++ b/framework/Torch.m
@@ -6,6 +6,45 @@
 
 @implementation Torch
 
+- (NSString *)bundleResourcesPathForFrameworkName:(NSString *)frameworkName
+{
+  return [[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:frameworkName] stringByAppendingPathComponent:@"Resources"];
+}
+
+- (void)addLuaPackagePathForBundlePath:(NSString *)bundlePath subdirectory:(NSString *)subdirectory
+{
+  NSMutableString *pathToAdd = [NSMutableString stringWithString:bundlePath];
+  if (subdirectory.length > 0) {
+    [pathToAdd appendString:@"/"];
+    [pathToAdd appendString:subdirectory];
+  }
+  [pathToAdd appendString:@"/?.lua"];
+  
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "path");
+  NSString *packagePath = [NSString stringWithUTF8String:lua_tostring(L, -1)];
+  
+  NSMutableString *updatedPath = [[NSMutableString alloc] initWithString:packagePath];
+  if (updatedPath.length > 0) {
+    [updatedPath appendString:@";"];
+  }
+  [updatedPath appendString:pathToAdd];
+  
+  lua_pop(L, 1);
+  lua_pushstring(L, updatedPath.UTF8String);
+  lua_setfield(L, -2, "path");
+  lua_pop(L, 1);
+}
+
+- (void)requireFrameworkPackage:(NSString *)package frameworkResourcesPath:(NSString *)resourcesPath
+{
+  NSString *path = [[resourcesPath stringByAppendingPathComponent:package] stringByAppendingPathComponent:@"init.lua"];
+  int ret = luaL_dofile(L, [path UTF8String]);
+  if (ret == 1) {
+    NSLog(@"could not load invalid lua resource: %@\n", package);
+  }
+}
+
 - (void)require:(NSString *)file
 {
     int ret = luaL_dofile(L, [[[NSBundle mainBundle] pathForResource:file ofType:@"lua"] UTF8String]);
@@ -16,37 +55,38 @@
 
 - (void)initialize
 {
-    // initialize Lua stack
-    lua_executable_dir("./lua");
-    L = lua_open();
-    luaL_openlibs(L);
+  // initialize Lua stack
+  lua_executable_dir("./lua");
+  L = lua_open();
+  luaL_openlibs(L);
+
+  NSString *frameworkResourcesPath = [self bundleResourcesPathForFrameworkName:@"Torch.framework"];
+  [self addLuaPackagePathForBundlePath:frameworkResourcesPath subdirectory:nil];
+
+  // load Torch
+  luaopen_libtorch(L);
+  [self requireFrameworkPackage:@"torch" frameworkResourcesPath:frameworkResourcesPath];
+
+  // load dok
+  [self requireFrameworkPackage:@"dok" frameworkResourcesPath:frameworkResourcesPath];
     
-    // load Torch
-    luaopen_libtorch(L);
-    [self require:@"torch"];
+  // load nn
+  luaopen_libnn(L);
+  [self requireFrameworkPackage:@"nn" frameworkResourcesPath:frameworkResourcesPath];
 
-    // load dok
-    [self require:@"dok"];
+  // load nnx
+  luaopen_libnnx(L);
+  [self requireFrameworkPackage:@"nnx" frameworkResourcesPath:frameworkResourcesPath];
+
+  // load image
+  luaopen_libimage(L);
+  [self requireFrameworkPackage:@"image" frameworkResourcesPath:frameworkResourcesPath];
+
+  // run user code
+  [self require:@"main"];
     
-    // load nn
-    luaopen_libnn(L);
-    [self require:@"nn"];
-
-    // load nnx
-    luaopen_libnnx(L);
-    [self require:@"nnx"];
-
-    // load image
-    luaopen_libimage(L);
-    [self require:@"image.lua"];
-
-    // run user code
-    [self require:@"main"];
-    lua_getfield(L, LUA_GLOBALSINDEX, "initialize");
-    lua_call(L, 0, 0);
-    
-    // done
-    return;
+  // done
+  return;
 }
 
 @end


### PR DESCRIPTION
Summary:
Requiring Torch packages and running Torch examples failed for a copule resource path related issues.
Framework bundle resources are stored in a specific path that is also different from the path used for main.lua (the application provided lua code and other resources).
Lua package.path is also unaware of the right place to look for resources.
One can also use the included code to allow Lua to find additional resources in the main bundle if they're located in some subdirectory.

Test Plan:
Create a test app that links against the produced Torch.framework.
Don't forget to copy bundle resources for the Torch.framework.
Use the new Torch.h and Torch.m files to initialize Torch.
