### PR TITLE
Fix require nnx

### DIFF
--- a/3rdparty/nnx/ReLU.lua
+++ b/3rdparty/nnx/ReLU.lua
@@ -1,5 +1,0 @@
-local ReLU, Parent = torch.class('nn.ReLU', 'nn.Threshold')
-
-function ReLU:__init(p)
-   Parent.__init(self,0,0)
-end

--- a/3rdparty/nnx/init.lua
+++ b/3rdparty/nnx/init.lua
@@ -63,7 +63,6 @@ torch.include('nnx', 'FunctionWrapper.lua')
 
 -- misc
 torch.include('nnx', 'Dropout.lua')
-torch.include('nnx', 'ReLU.lua')
 torch.include('nnx', 'SaturatedLU.lua')
 torch.include('nnx', 'Minus.lua')
 

--- a/framework/Torch.m
+++ b/framework/Torch.m
@@ -13,13 +13,27 @@
 
 - (void)addLuaPackagePathForBundlePath:(NSString *)bundlePath subdirectory:(NSString *)subdirectory
 {
+  // Add path for finding individual lua files
   NSMutableString *pathToAdd = [NSMutableString stringWithString:bundlePath];
   if (subdirectory.length > 0) {
     [pathToAdd appendString:@"/"];
     [pathToAdd appendString:subdirectory];
   }
   [pathToAdd appendString:@"/?.lua"];
+  [self appendLuaPackagePathWithPath:pathToAdd];
   
+  // Add path for finding packages that are prepared with init.lua
+  pathToAdd = [NSMutableString stringWithString:bundlePath];
+  if (subdirectory.length > 0) {
+    [pathToAdd appendString:@"/"];
+    [pathToAdd appendString:subdirectory];
+  }
+  [pathToAdd appendString:@"/?/init.lua"];
+  [self appendLuaPackagePathWithPath:pathToAdd];
+}
+
+- (void)appendLuaPackagePathWithPath:(NSString *)pathToAdd
+{
   lua_getglobal(L, "package");
   lua_getfield(L, -1, "path");
   NSString *packagePath = [NSString stringWithUTF8String:lua_tostring(L, -1)];
@@ -60,6 +74,7 @@
   L = lua_open();
   luaL_openlibs(L);
 
+  [self addLuaPackagePathForBundlePath:[[NSBundle mainBundle] resourcePath] subdirectory:nil];
   NSString *frameworkResourcesPath = [self bundleResourcesPathForFrameworkName:@"Torch.framework"];
   [self addLuaPackagePathForBundlePath:frameworkResourcesPath subdirectory:nil];
 


### PR DESCRIPTION
2 issues:
1) nn now has a copy of ReLu that conflicts when nnx is also including it
2) We need to allow package paths where the init.lua is implicit (require 'package_name')
