### PR TITLE
use the correct values for ios examples

### DIFF
--- a/ios_examples/XOR_Example/XOR_Example/ViewController.m
+++ b/ios_examples/XOR_Example/XOR_Example/ViewController.m
@@ -78,7 +78,7 @@
   THFloatStorage *classification_storage = THFloatStorage_newWithSize1(2);
   THFloatTensor *classification = THFloatTensor_newWithStorage1d(classification_storage, 1, 2, 1);
   THTensor_fastSet1d(classification, 0, obj.x);
-  THTensor_fastSet1d(classification, 1, obj.x);
+  THTensor_fastSet1d(classification, 1, obj.y);
   lua_getglobal(L,"classifyExample");
   luaT_pushudata(L, classification, "torch.FloatTensor");
   

--- a/ios_examples/XOR_Example_LoadPretrained/XOR_Example/ViewController.m
+++ b/ios_examples/XOR_Example_LoadPretrained/XOR_Example/ViewController.m
@@ -79,7 +79,7 @@
   THFloatStorage *classification_storage = THFloatStorage_newWithSize1(2);
   THFloatTensor *classification = THFloatTensor_newWithStorage1d(classification_storage, 1, 2, 1);
   THTensor_fastSet1d(classification, 0, obj.x);
-  THTensor_fastSet1d(classification, 1, obj.x);
+  THTensor_fastSet1d(classification, 1, obj.y);
   lua_getglobal(L,"classifyExample");
   luaT_pushudata(L, classification, "torch.FloatTensor");
   


### PR DESCRIPTION
Classification tensor was having obj.x set to both values. Fixed now.
